### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project was originally adapted from tailrecursion's
 [ring-proxy](https://github.com/tailrecursion/ring-proxy) middleware, and is
-meant for use with the [Trapperkeeper Jetty10 Webservice](https://github.com/openvoxproject/trapperkeeper-webserver-jetty10).  It also contains common ring middleware between Puppet projects and helpers to be used with the middleware.
+meant for use with the [Trapperkeeper Webservice](https://github.com/openvoxproject/trapperkeeper-webserver).  It also contains common ring middleware between Puppet projects and helpers to be used with the middleware.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.openvoxproject/ring-middleware "2.1.9-SNAPSHOT"
+(defproject org.openvoxproject/ring-middleware "2.2.0-SNAPSHOT"
 
   ;; Generally, try to keep version pins in :managed-dependencies and the libraries
   ;; this project actually uses in :dependencies, inheriting the version from
@@ -15,7 +15,7 @@
                          [org.openvoxproject/http-client "2.2.7"]
                          [org.openvoxproject/kitchensink "3.5.7" :classifier "test" :scope "test"]
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test" :scope "test"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]
                          [org.slf4j/slf4j-api "2.0.17"]
                          [ring/ring-codec "1.3.0"]
                          [ring/ring-core "1.14.2"]]
@@ -44,4 +44,4 @@
                                   [org.bouncycastle/bcpkix-jdk18on]
                                   [org.openvoxproject/kitchensink :classifier "test" :scope "test"]
                                   [org.openvoxproject/trapperkeeper :classifier "test" :scope "test"]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10]]}})
+                                  [org.openvoxproject/trapperkeeper-webserver]]}})

--- a/test/puppetlabs/ring_middleware/core_test.clj
+++ b/test/puppetlabs/ring_middleware/core_test.clj
@@ -10,7 +10,7 @@
             [puppetlabs.ssl-utils.core :refer [pem->cert]]
             [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :refer :all]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [ring.util.response :as rr]
@@ -128,7 +128,7 @@
 (defmacro with-target-and-proxy-servers
   [{:keys [target proxy proxy-handler ring-handler endpoint target-endpoint]} & body]
   `(with-app-with-config proxy-target-app#
-     [jetty10-service]
+     [jetty-service]
      {:webserver ~target}
      (let [target-webserver# (get-service proxy-target-app# :WebserverService)]
        (add-ring-handler
@@ -144,7 +144,7 @@
         post-target-handler
         "/hello/post"))
      (with-app-with-config proxy-app#
-       [jetty10-service]
+       [jetty-service]
        {:webserver ~proxy}
        (let [proxy-webserver# (get-service proxy-app# :WebserverService)]
          (add-ring-handler proxy-webserver# ~proxy-handler ~endpoint))


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
